### PR TITLE
Enable non-standard ports

### DIFF
--- a/snmp/v1/__init__.py
+++ b/snmp/v1/__init__.py
@@ -65,7 +65,7 @@ def _listen_thread(sock, pipe, requests, rlock, data, dlock, port=PORT):
 
         # listen for UDP packets from the correct port
         packet, (host, p) = sock.recvfrom(RECV_SIZE)
-        if p != PORT:
+        if p != port:
             continue
 
         try:
@@ -200,7 +200,7 @@ def _monitor_thread(sock, done, requests, rlock, data, dlock, port=PORT, resend=
             if count:
                 msg = "Resending to {} (ID={})"
                 log.debug(msg.format(host, message.data.request_id))
-                sock.sendto(message.serialize(), (host, PORT))
+                sock.sendto(message.serialize(), (host, port))
             else:
                 with dlock:
                     msg = "Request to {} timed out (ID={})"


### PR DESCRIPTION
Corrects the port variable in a couple of places to allow non-standard ports to work correctly. Before this change the replies are ignored as they are compared to the PORT constant instead of the port variable, and then the retry is sent to the PORT constant instead of the port variable, effectively blocking any attempts to use non-standard ports.