### PR TITLE
Assorted fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+dist
+*.egg-info
+**/__pycache__

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,6 @@ packages =
     snmp.security.usm
     snmp.security.usm.priv
     snmp.transport
-    snmp.transport.nt
+    snmp.transport.generic
     snmp.transport.posix
 python_requires = >=3.6

--- a/snmp/ber.py
+++ b/snmp/ber.py
@@ -137,4 +137,4 @@ def decode(data, expected=None, leftovers=False, copy=True):
             return body
 
 def encode(identifier, data):
-    return encode_identifier(identifier) + encode_length(len(data)) + data
+    return encode_identifier(identifier) + encode_length(len(data)) + (data if isinstance(data,bytes) else bytes(data, "latin_1"))

--- a/snmp/message/v1.py
+++ b/snmp/message/v1.py
@@ -29,7 +29,7 @@ class ResponseMismatch(IncomingMessageError):
 
 class CacheEntry:
     def __init__(self, handle, community):
-        self.community = community
+        self.community = community if isinstance (community, bytes) else bytes (community, "latin_1")
         self.handle = weakref.ref(handle)
 
 class MessageProcessor:

--- a/snmp/message/v2c.py
+++ b/snmp/message/v2c.py
@@ -33,7 +33,7 @@ class ResponseMismatch(IncomingMessageError):
 
 class CacheEntry:
     def __init__(self, handle, community):
-        self.community = community
+        self.community = community if isinstance (community, bytes) else bytes (community, "latin_1")
         self.handle = weakref.ref(handle)
 
 class MessageProcessor:


### PR DESCRIPTION
Couple of fixes for things that cropped up while trying to use the library:

* `snmp.transport.nt.udp` was renamed to `snmp.transport.generic.udp`, but `setup.cfg` was not updated... so I updated it.
* `data` in `snmp.ber.encode()` is not always a `bytes`, but when it isn't it seems to be a `str`. The fix was a conditional conversion.
* In `snmp.message.v2c.MessageProcessor.prepareDataElements()` a comparison is made between `entry.community` (`str`) and `message.community` (`bytes`), which obviously doesn't work. To fix this I added a conditional conversion in `snmp.message.v2c.CacheEntry.__init__()`.

And while working on this I discovered the lack of a `.gitignore`. What I added is by no means complete, but it gets rid of the build and install cruft while working on the code.